### PR TITLE
Fix PR number in the preview path

### DIFF
--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -35,4 +35,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: notebooks/_build/html
           enable_jekyll: false
-          destination_dir: _preview/${{ github.event.number }}
+          destination_dir: _preview/${{ github.event.issue.number }}


### PR DESCRIPTION
Following this advice https://github.com/actions/checkout/issues/58#issuecomment-663103947, it seems that ${{github.event.issue.number}} should always resolve to the PR number, even on subsequent pushes to the branch.

Hopefully this fixes the missing PR number in the preview path.