### PR TITLE
Speed up test builds by caching the mamba environment

### DIFF
--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -10,17 +10,28 @@ jobs:
         shell: bash -l {0}
     steps:
       - uses: actions/checkout@v3
-      - name: Setup conda environment
-        uses: conda-incubator/setup-miniconda@master
+
+      - name: Setup Mambaforge
+        uses: conda-incubator/setup-miniconda@v2
         with:
-          channels: conda-forge
-          channel-priority: strict
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
           activate-environment: radar-cookbook-dev
-          auto-update-conda: false
-          python-version: 3.8
-          environment-file: environment.yml
-          mamba-version: '*'
           use-mamba: true
+
+      - name: Set cache date
+        run: echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
+
+      - uses: actions/cache@v3
+        with:
+          path: /usr/share/miniconda3/envs/radar-cookbook-dev
+          key: linux-64-conda-${{ hashFiles('environment.yml') }}-${{ env.DATE }}-${{ env.CACHE_NUMBER }}
+        id: cache
+
+      - name: Update environment
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: mamba env update -n radar-cookbook-dev -f environment.yml
+
       - name: Build the book
         run: |
           jupyter-book build notebooks/

--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -17,17 +17,26 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      # Install dependencies
-      - uses: conda-incubator/setup-miniconda@master
+      - name: Setup Mambaforge
+        uses: conda-incubator/setup-miniconda@v2
         with:
-          channels: conda-forge
-          channel-priority: strict
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
           activate-environment: radar-cookbook-dev
-          auto-update-conda: false
-          python-version: 3.8
-          environment-file: environment.yml
-          mamba-version: '*'
           use-mamba: true
+
+      - name: Set cache date
+        run: echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
+
+      - uses: actions/cache@v3
+        with:
+          path: /usr/share/miniconda3/envs/radar-cookbook-dev
+          key: linux-64-conda-${{ hashFiles('environment.yml') }}-${{ env.DATE }}-${{ env.CACHE_NUMBER }}
+        id: cache
+
+      - name: Update environment
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: mamba env update -n radar-cookbook-dev -f environment.yml
       # Build the book
       - name: Build the book
         run: |

--- a/environment.yml
+++ b/environment.yml
@@ -2,6 +2,7 @@ name: radar-cookbook-dev
 channels:
   - conda-forge
 dependencies:
+  - python=3.8
   - jupyter-book
   - matplotlib
   - cartopy

--- a/notebooks/landing-page.md
+++ b/notebooks/landing-page.md
@@ -1,7 +1,5 @@
 # Radar Cookbook
 
-**IGNORE THIS PLEASE**
-
 This Project Pythia Cookbook covers the basics of working with weather radar data in Python.
 
 ## Motivation

--- a/notebooks/landing-page.md
+++ b/notebooks/landing-page.md
@@ -1,5 +1,7 @@
 # Radar Cookbook
 
+**IGNORE THIS PLEASE**
+
 This Project Pythia Cookbook covers the basics of working with weather radar data in Python.
 
 ## Motivation


### PR DESCRIPTION
This PR changes how the build environment is created. First, we use mambaforge for top speed in solving the environment. Next, we attempt to cache the environment for reuse.

The cached environment is date stamped so will be not be reused after the day it is created. But this should dramatically speed up the preview builds as people are working on PRs.

The environment is also rebuilt whenever the `environment.yml` file changes.