### PR TITLE
Add link-checker action for PRs

### DIFF
--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -1,0 +1,54 @@
+name: link-checker
+
+on:
+  pull_request:
+  workflow_dispatch:
+  # schedule:
+  #   - cron: '30 0 * * SUN' # Sunday “At 00:30”
+
+jobs:
+  link-checker:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - name: Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
+      - uses: actions/checkout@v3
+
+      - name: Setup Mambaforge
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+          activate-environment: radar-cookbook-dev
+          use-mamba: true
+
+      - name: Set cache date
+        run: echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
+
+      - uses: actions/cache@v3
+        with:
+          path: /usr/share/miniconda3/envs/radar-cookbook-dev
+          key: linux-64-conda-${{ hashFiles('environment.yml') }}-${{ env.DATE }}-${{ env.CACHE_NUMBER }}
+        id: cache
+
+      - name: Update environment
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: mamba env update -n radar-cookbook-dev -f environment.yml
+
+      - name: Disable notebook execution
+        shell: python
+        run: |
+          import yaml
+          with open('notebooks/_config.yml') as f:
+            data = yaml.safe_load(f)
+          data['execute']['execute_notebooks'] = 'off'
+          with open('notebooks/_config.yml', 'w') as f:
+            yaml.dump(data, f)
+      - name: Check external links
+        run: |
+          jupyter-book build --builder linkcheck notebooks/


### PR DESCRIPTION
This will run a link-checker action on PRs.

Like we do for Foundations, this action disables notebook execution during the jupyter-book build stage to save time.