### PR TITLE
Refactor workflows to be more resusable

### DIFF
--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -1,9 +1,21 @@
 name: build-book
+
 on:
-  pull_request:
-  workflow_dispatch:
-  schedule:
-    - cron: '0 0 * * *' # Daily “At 00:00”
+  workflow_call:
+    inputs:
+      environment_name:
+        description: 'Name of conda environment to activate'
+        required: true
+        type: string
+      environment_file:
+        description: 'Name of conda environment file'
+        required: false
+        default: 'environment.yml'
+        type: string
+      path_to_notebooks:
+        description: 'Location of the JupyterBook source relative to repo root'
+        required: false
+        default: './'
 
 jobs:
   build:
@@ -19,7 +31,7 @@ jobs:
         with:
           miniforge-variant: Mambaforge
           miniforge-version: latest
-          activate-environment: radar-cookbook-dev
+          activate-environment: ${{ inputs.environment_name }}
           use-mamba: true
 
       - name: Set cache date
@@ -27,17 +39,17 @@ jobs:
 
       - uses: actions/cache@v3
         with:
-          path: /usr/share/miniconda3/envs/radar-cookbook-dev
-          key: linux-64-conda-${{ hashFiles('environment.yml') }}-${{ env.DATE }}-${{ env.CACHE_NUMBER }}
+          path: /usr/share/miniconda3/envs/${{ inputs.environment_name }}
+          key: linux-64-conda-${{ hashFiles('${{ inputs.environment_file }}') }}-${{ env.DATE }}-${{ env.CACHE_NUMBER }}
         id: cache
 
       - name: Update environment
         if: steps.cache.outputs.cache-hit != 'true'
-        run: mamba env update -n radar-cookbook-dev -f environment.yml
+        run: mamba env update -n ${{ inputs.environment_name }} -f ${{ inputs.environment_file }}
 
       - name: Build the book
         run: |
-          jupyter-book build notebooks/
+          jupyter-book build ${{ inputs.path_to_notebooks }}
       - name: Zip the book
         run: |
           set -x
@@ -45,9 +57,9 @@ jobs:
           if [ -f book.zip ]; then
               rm -rf book.zip
           fi
-          zip -r book.zip notebooks/_build/html
+          zip -r book.zip ${{ inputs.path_to_notebooks }}/_build/html
       - name: Upload zipped book artifact
         uses: actions/upload-artifact@v3
         with:
-          name: book-zip-${{github.event.pull_request.number}}
+          name: book-zip-${{github.event.number}}
           path: ./book.zip

--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -7,48 +7,39 @@ on:
       - main
   workflow_dispatch:
 
-# This job installs dependencies, build the book, and pushes it to `gh-pages`
 jobs:
-  build-and-deploy-book:
+  build:
+    uses: ./.github/build-book.yaml
+      with:
+        environment_name: radar-cookbook-dev
+        environment_file: environment.yml
+        path_to_notebooks: notebooks/
+
+  deploy:
+    needs: build
     runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v3
-
-      - name: Setup Mambaforge
-        uses: conda-incubator/setup-miniconda@v2
+      - name: Download Artifact Book
+        uses: dawidd6/action-download-artifact@v2.21.0
         with:
-          miniforge-variant: Mambaforge
-          miniforge-version: latest
-          activate-environment: radar-cookbook-dev
-          use-mamba: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: build-book.yaml
+          commit: ${{ github.sha }}
+          name: book-zip-${{ github.event.number }}
 
-      - name: Set cache date
-        run: echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
-
-      - uses: actions/cache@v3
-        with:
-          path: /usr/share/miniconda3/envs/radar-cookbook-dev
-          key: linux-64-conda-${{ hashFiles('environment.yml') }}-${{ env.DATE }}-${{ env.CACHE_NUMBER }}
-        id: cache
-
-      - name: Update environment
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: mamba env update -n radar-cookbook-dev -f environment.yml
-        
-      # Build the book
-      - name: Build the book
+      - name: Unzip the book
         run: |
-          cd notebooks
-          jupyter-book build .
+          rm -rf notebooks/_build/html
+          unzip book.zip
+          rm -f book.zip
 
-      # Deploy the book's HTML to gh-pages branch
-      - name: GitHub Pages action
+      - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3.8.0
         if: github.ref == 'refs/heads/main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: notebooks/_build/html
-          keep_files: true  # This should preserve existing previews from other PRs
+          keep_files: true  # This preserves existing previews from open PRs

--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -2,7 +2,7 @@ name: deploy-preview
 on:
   workflow_run:
     workflows:
-      - build-book
+      - trigger-book-build
     types:
       - requested
       - completed

--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -1,10 +1,21 @@
 name: link-checker
 
 on:
-  pull_request:
-  workflow_dispatch:
-  schedule:
-    - cron: '10 0 * * *' # Daily “At 00:10”
+  workflow_call:
+    inputs:
+      environment_name:
+        description: 'Name of conda environment to activate'
+        required: true
+        type: string
+      environment_file:
+        description: 'Name of conda environment file'
+        required: false
+        default: 'environment.yml'
+        type: string
+      path_to_notebooks:
+        description: 'Location of the JupyterBook source relative to repo root'
+        required: false
+        default: './'
 
 jobs:
   link-checker:
@@ -24,7 +35,7 @@ jobs:
         with:
           miniforge-variant: Mambaforge
           miniforge-version: latest
-          activate-environment: radar-cookbook-dev
+          activate-environment: ${{ inputs.environment_name }}
           use-mamba: true
 
       - name: Set cache date
@@ -32,23 +43,23 @@ jobs:
 
       - uses: actions/cache@v3
         with:
-          path: /usr/share/miniconda3/envs/radar-cookbook-dev
-          key: linux-64-conda-${{ hashFiles('environment.yml') }}-${{ env.DATE }}-${{ env.CACHE_NUMBER }}
+          path: /usr/share/miniconda3/envs/${{ inputs.environment_name }}
+          key: linux-64-conda-${{ hashFiles('${{ inputs.environment_file }}') }}-${{ env.DATE }}-${{ env.CACHE_NUMBER }}
         id: cache
 
       - name: Update environment
         if: steps.cache.outputs.cache-hit != 'true'
-        run: mamba env update -n radar-cookbook-dev -f environment.yml
+        run: mamba env update -n ${{ inputs.environment_name }} -f ${{ inputs.environment_file }}
 
       - name: Disable notebook execution
         shell: python
         run: |
           import yaml
-          with open('notebooks/_config.yml') as f:
+          with open('${{ inputs.path_to_notebooks }}/_config.yml') as f:
             data = yaml.safe_load(f)
           data['execute']['execute_notebooks'] = 'off'
-          with open('notebooks/_config.yml', 'w') as f:
+          with open('${{ inputs.path_to_notebooks }}/_config.yml', 'w') as f:
             yaml.dump(data, f)
       - name: Check external links
         run: |
-          jupyter-book build --builder linkcheck notebooks/
+          jupyter-book build --builder linkcheck ${{ inputs.path_to_notebooks }}

--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -1,0 +1,20 @@
+name: nightly-build
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *' # Daily “At 00:00”
+
+jobs:
+  build:
+    uses: ./.github/build-book.yaml
+      with:
+        environment_name: radar-cookbook-dev
+        environment_file: environment.yml
+        path_to_notebooks: notebooks/
+  link-check:
+    uses: ./.github/link-checker.yaml
+      with:
+        environment_name: radar-cookbook-dev
+        environment_file: environment.yml
+        path_to_notebooks: notebooks/

--- a/.github/workflows/trigger-book-build.yaml
+++ b/.github/workflows/trigger-book-build.yaml
@@ -1,0 +1,20 @@
+name: trigger-book-build
+on:
+  pull_request:
+  # workflow_dispatch:
+  # schedule:
+  #   - cron: '0 0 * * *' # Daily “At 00:00”
+
+jobs:
+  build:
+    uses: ./.github/build-book.yaml
+      with:
+        environment_name: radar-cookbook-dev
+        environment_file: environment.yml
+        path_to_notebooks: notebooks/
+  link-check:
+    uses: ./.github/link-checker.yaml
+      with:
+        environment_name: radar-cookbook-dev
+        environment_file: environment.yml
+        path_to_notebooks: notebooks/


### PR DESCRIPTION
Here I refactor the workflows code with more reusable components.

The idea is that we can abstract some of this machinery away so it doesn't need to be repeated or edited in each individual cookbook repo.

Should also solve the problem of inadvertent nightly triggering of the `deploy-preview.yaml` action that I mentioned in #6 