### PR TITLE
Update actions to be consistent with latest template

### DIFF
--- a/.github/workflows/build-book.yaml
+++ b/.github/workflows/build-book.yaml
@@ -5,7 +5,8 @@ on:
     inputs:
       environment_name:
         description: 'Name of conda environment to activate'
-        required: true
+        required: false
+        default: 'cookbook-dev'
         type: string
       environment_file:
         description: 'Name of conda environment file'
@@ -17,6 +18,11 @@ on:
         required: false
         default: './'
         type: string
+      use_cached_environment:
+        description: 'Flag for whether we should attempt to retrieve a previously cached environment.'
+        required: false
+        default: 'true'
+        type: string  # had a lot of trouble with boolean types, see https://github.com/actions/runner/issues/1483
 
 jobs:
   build:
@@ -36,16 +42,20 @@ jobs:
           use-mamba: true
 
       - name: Set cache date
+        if: ${{ inputs.use_cached_environment == 'true' }}
         run: echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
 
       - uses: actions/cache@v3
+        if: inputs.use_cached_environment == 'true'
         with:
           path: /usr/share/miniconda3/envs/${{ inputs.environment_name }}
-          key: linux-64-conda-${{ hashFiles('${{ inputs.environment_file }}') }}-${{ env.DATE }}-${{ env.CACHE_NUMBER }}
+          key: linux-64-conda-${{ hashFiles('${{ inputs.environment_file }}') }}-${{ env.DATE }}
         id: cache
 
       - name: Update environment
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: |
+          inputs.use_cached_environment != 'true'
+          || steps.cache.outputs.cache-hit != 'true'
         run: mamba env update -n ${{ inputs.environment_name }} -f ${{ inputs.environment_file }}
 
       - name: Build the book

--- a/.github/workflows/deploy-book.yaml
+++ b/.github/workflows/deploy-book.yaml
@@ -23,11 +23,8 @@ jobs:
         shell: bash -l {0}
     steps:
       - name: Download Artifact Book
-        uses: dawidd6/action-download-artifact@v2.21.1
+        uses: actions/download-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          workflow: build-book.yaml
-          commit: ${{ github.sha }}
           name: book-zip-${{ github.event.number }}
 
       - name: Unzip the book

--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -91,7 +91,7 @@ jobs:
           github.event.workflow_run.conclusion == 'success'
           && steps.find-pull-request.outputs.number != ''
           && steps.fc.outputs.comment-id != ''
-        uses: dawidd6/action-download-artifact@v2.21.1
+        uses: dawidd6/action-download-artifact@v2.21.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: build-book.yaml

--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -5,7 +5,8 @@ on:
     inputs:
       environment_name:
         description: 'Name of conda environment to activate'
-        required: true
+        required: false
+        default: 'cookbook-dev'
         type: string
       environment_file:
         description: 'Name of conda environment file'
@@ -16,6 +17,11 @@ on:
         description: 'Location of the JupyterBook source relative to repo root'
         required: false
         default: './'
+        type: string
+      use_cached_environment:
+        description: 'Flag for whether we should attempt to retrieve a previously cached environment.'
+        required: false
+        default: 'true'
         type: string
 
 jobs:
@@ -40,16 +46,20 @@ jobs:
           use-mamba: true
 
       - name: Set cache date
+        if: inputs.use_cached_environment == 'true'
         run: echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
 
       - uses: actions/cache@v3
+        if: inputs.use_cached_environment == 'true'
         with:
           path: /usr/share/miniconda3/envs/${{ inputs.environment_name }}
-          key: linux-64-conda-${{ hashFiles('${{ inputs.environment_file }}') }}-${{ env.DATE }}-${{ env.CACHE_NUMBER }}
+          key: linux-64-conda-${{ hashFiles('${{ inputs.environment_file }}') }}-${{ env.DATE }}
         id: cache
 
       - name: Update environment
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: |
+          inputs.use_cached_environment != 'true'
+          || steps.cache.outputs.cache-hit != 'true'
         run: mamba env update -n ${{ inputs.environment_name }} -f ${{ inputs.environment_file }}
 
       - name: Disable notebook execution

--- a/.github/workflows/trigger-book-build.yaml
+++ b/.github/workflows/trigger-book-build.yaml
@@ -1,20 +1,19 @@
 name: trigger-book-build
 on:
   pull_request:
-  # workflow_dispatch:
-  # schedule:
-  #   - cron: '0 0 * * *' # Daily “At 00:00”
 
 jobs:
   build:
-    uses: ProjectPythiaTutorials/radar-cookbook/.github/workflows/build-book.yaml@main
+    uses: ./.github/workflows/build-book.yaml
     with:
       environment_name: radar-cookbook-dev
       environment_file: environment.yml
       path_to_notebooks: notebooks/
+      use_cached_environment: 'true'  # This is default, not strickly needed. Set to 'false' to always build a new environment
   link-check:
-    uses: ProjectPythiaTutorials/radar-cookbook/.github/workflows/link-checker.yaml@main
+    uses: ./.github/workflows/link-checker.yaml
     with:
       environment_name: radar-cookbook-dev
       environment_file: environment.yml
       path_to_notebooks: notebooks/
+      use_cached_environment: 'true'


### PR DESCRIPTION
Once merged, this should fix the failure at the `deploy-book` stage, e.g. https://github.com/ProjectPythiaTutorials/radar-cookbook/runs/6971598476?check_suite_focus=true